### PR TITLE
Update section titles and language for student readability

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Twitter), the interaction goes something like this:
 If all goes as it should, the entire interaction only takes a second or two. But
 even this small interaction demonstrates all the concepts of front end web programming.
 
-### The "Three Pillars of Web Programming"
+### Flatiron's "Three Pillars of Web Programming"
 
 We can break down web programming into three essential "pillars": 
 

--- a/README.md
+++ b/README.md
@@ -1,33 +1,34 @@
-# Demonstrate a Front-End Web Programming Example
+# Intro to Front-End Web Programming
 
 ## Learning Goals
 
 - Define web programming
-- Identify reference example
 - Identify the "Three Pillars of Web Programming"
+- Recognize web programming in an example
 
 ## Introduction
 
-"Front-End Web Programming" is a phrase that gets used in a lot of places by a
-lot of people. In this lesson we're going to create a common definition of "web
-programming" and show one example that demonstrates all of "web programming's"
-parts.
+The phrase "Front-End Web Programming" is used in different ways by different
+people. In this lesson we're going to choose a definition of "web
+programming" and show an example that demonstrates the different parts of "web programming",
+so that we know our objective for the next set of lessons.
 
-### Define Web Programming
+### Defining Web Programming
 
 Web programming, at its heart, is:
 
-> Creating documents with HTML, styling / positioning the document's content
-> with CSS, and using JavaScript to provide interactivity / notify remote
-> servers.
+> * Creating documents with HTML
+> * Styling the document's content with CSS
+> * Adding action and interactivity with Javascript
 
-When a document has a lot of JavaScript code so that the page feels closer to a
-computer application, people call it a "**web application**." There's no clear
-line like "When there's three or more actions it's a web application!" That means
-individuals' boundaries are different, but it's an application when it feels
-"rich."
+When a document has a lot of JavaScript code, the page feels closer to a
+computer application, so people call it a "**web application**." There's 
+no clear distinction between "web sites" and "web applications" like "When
+there's three or more actions it's a web application!". Different people 
+draw the boundary differently. More or less, we call a page an "application"
+when it feels "rich."
 
-## Identify Reference Example
+## Example: Favoriting a Social Media Post
 
 While this might be your first introduction to looking at some of your favorite
 sites with "web programmer" eyes, you've probably experienced plenty of web
@@ -38,7 +39,7 @@ example.
 > **Web Programming Example**: "Favoriting" a social media post.
 
 Regardless of the social media site (Instagram, Pinterest, Facebook, LinkedIn,
-Twitter), the interaction went something like this:
+Twitter), the interaction goes something like this:
 
 1. The site renders some HTML content that is styled using CSS
 2. You see the content and decide to show your approval of it
@@ -46,18 +47,24 @@ Twitter), the interaction went something like this:
    thumbs-up, +1, etc.). For example: <img src="https://curriculum-content.s3.amazonaws.com/fewpjs/fewpjs-fewp-example/empty.png" alt="Twitter empty heart">
 4. The visual element _updates_ (animates, goes from empty to full, jiggles, etc) like:  <img src="https://curriculum-content.s3.amazonaws.com/fewpjs/fewpjs-fewp-example/full.png" alt="Twitter full heart">
 5. Behind the scenes, the application _tells the provider_ that this
-   post has gained your approval so that the central provider can notify 
-   the creator or something similar
+   post has gained your approval so that the central provider can store
+   this information and use it later (for example, to notify the post 
+   author that you liked their post).
 
-If all goes as it should, the entire process only takes a second or two. But
-in this moment we did _all_ the work of front end web programming.
+If all goes as it should, the entire interaction only takes a second or two. But
+even this small interaction demonstrates all the concepts of front end web programming.
 
-### Identify the "Three Pillars of Web Programming"
+### The "Three Pillars of Web Programming"
 
-We can break down web programming into three essential "pillars": In the
-previous list, we _italicized_  the characteristic verb in steps 3-5. Each of those
-words exemplifies the activity of one of the "pillars" we must learn in order to be
-web programmers.
+We can break down web programming into three essential "pillars": 
+
+- **Recognize Events**
+- **Manipulate the DOM**
+- **Communicate with the Server**
+
+In the steps of the Favoriting a Social Media Post example, we _italicized_  
+the characteristic verb in steps 3-5. Each of those words exemplifies the 
+activity of one of the "pillars" we must learn in order to make web applications.
 
   - Step 3 showed "**Recognizing JS events**:" Your _click_ action on the empty heart
     tells JavaScript to do work
@@ -68,16 +75,18 @@ web programmers.
     content
 
 Now you know what's going on when you click that heart! The next lessons will
-focus on explaining each of the "pillars" to you. After you've worked your way through them, your new "web
-programmer" eyes will have you looking at your favorite sites very differently.
+focus on explaining each of these "pillars" in more detail. After you've worked 
+your way through them, your new "web programmer" eyes will have you looking at
+your favorite sites very differently.
 
 ## Conclusion
 
 Web Programming is creating documents with HTML, styling / positioning the
-documents' content with CSS and updating that content and servers based on
-events using JavaScript. We can break down web programming into three pillars
-that involve working with the DOM, JavaScript eventing and communication with
-the server. Now that we've seen how these elements are connected in principle,
-we can now move on to seeing how they work together in practice.
+documents' content with CSS, and updating that content and servers based on
+events using JavaScript. We can break down the Javascript part of web 
+programming into three pillars that involve working with the DOM, Javascript
+eventing and communication with the server. Now that we've seen how these
+pillars are connected in the abstract, we are ready to dive in to seeing how they
+work together in detail.
 
 <p class='util--hide'>View <a href='https://learn.co/lessons/fewpjs-fewp-example'>Front-End Web Programming Example</a> on Learn.co and start learning to code for free.</p>


### PR DESCRIPTION
Updated language around 'Three Pillars' to reflect that it's a Flatiron term, not an industry standard

Titles and headings sounded stilted (possibly based on the curriculum team workflow and patterns, not clarity for students?) 

Some minor content updates for clarity.

Changes:
- title and section names to more 'expected' names for students
- add bullet points to break down paragraphs
- rephrasing some paragraphs